### PR TITLE
feat: add support php 8.5

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.5]
+        php: [8.2, 8.3, 8.4, 8.5]
         laravel: [11.*, 12.*]
         dependency-version: [prefer-lowest, prefer-stable]
         include:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.2, 8.3, 8.4]
+        php: [8.5]
         laravel: [11.*, 12.*]
         dependency-version: [prefer-lowest, prefer-stable]
         include:

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
 		}
 	],
 	"require": {
-		"php": "8.5.*",
+		"php": "^8.2",
 		"laravel/framework": "^11.0|^12.0",
 		"league/statsd": "1.3.*"
 	},

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
 		}
 	],
 	"require": {
-		"php": "^8.2",
+		"php": "8.5.*",
 		"laravel/framework": "^11.0|^12.0",
 		"league/statsd": "1.3.*"
 	},


### PR DESCRIPTION
This pull request updates the project's PHP version requirements to target only PHP 8.5, removing support for earlier versions. This ensures the codebase and automated tests are aligned with the latest PHP release.

**Dependency and CI configuration updates:**

* Updated the PHP version constraint in `composer.json` to require only `8.5.*`, removing support for PHP 8.2 and 8.3.
* Updated the GitHub Actions test matrix in `.github/workflows/tests.yml` to run tests exclusively on PHP 8.5.

Ref: #57416