### PR TITLE
ci: add support for laravel 13

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,6 @@
 name: tests
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   tests:
@@ -10,15 +10,27 @@ jobs:
       fail-fast: true
       matrix:
         php: [8.2, 8.3, 8.4, 8.5]
-        laravel: [11.*, 12.*]
+        laravel: [11.*, 12.*, 13.*]
+        phpunit: [11.*, 12.*]
         dependency-version: [prefer-lowest, prefer-stable]
         include:
           - laravel: 11.*
             testbench: 9.*
           - laravel: 12.*
             testbench: 10.*
+          - laravel: 13.*
+            testbench: 11.*
+        exclude:
+          - laravel: 11.*
+            phpunit: 12.*
+          - laravel: 12.*
+            phpunit: 12.*
+          - laravel: 13.*
+            phpunit: 11.*
+          - laravel: 13.*
+            php: 8.2
 
-    name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
+    name: P${{ matrix.php }} - L${{ matrix.laravel }} - U${{ matrix.phpunit }} - ${{ matrix.dependency-version }}
 
     steps:
       - name: Checkout code
@@ -33,7 +45,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "phpunit/phpunit:${{ matrix.phpunit }}" --no-interaction --no-update
           composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
 
       - name: Execute tests

--- a/composer.json
+++ b/composer.json
@@ -10,15 +10,15 @@
 	],
 	"require": {
 		"php": "^8.2",
-		"laravel/framework": "^11.0|^12.0",
+		"laravel/framework": "^11.0|^12.0|^13.0",
 		"league/statsd": "1.3.*"
 	},
 	"require-dev": {
 		"exolnet/phpcs-config": "^2.0",
 		"mockery/mockery": "^1.4",
-		"phpunit/phpunit" : "^11.5.3",
-		"orchestra/testbench": "^9.0|^10.0",
-		"illuminate/contracts": "^11.0|^12.0",
+		"phpunit/phpunit" : "^11.5.3|^12.0",
+		"orchestra/testbench": "^9.0|^10.0|^11.0",
+		"illuminate/contracts": "^11.0|^12.0|^13.0",
 		"squizlabs/php_codesniffer": "^3.6"
 	},
 	"autoload": {


### PR DESCRIPTION
Ref #58942

This pull request updates the project to support Laravel 13 and PHPUnit 12, and makes corresponding adjustments to the GitHub Actions test workflow and Composer dependencies. The changes ensure compatibility with the latest versions of Laravel and PHPUnit, and improve the test matrix for more granular testing.

**Dependency and compatibility updates:**

* Added support for Laravel 13 and PHPUnit 12 in both `require` and `require-dev` sections of `composer.json`, as well as for `orchestra/testbench` and `illuminate/contracts` dependencies.

**CI workflow improvements:**

* Expanded the GitHub Actions test matrix in `.github/workflows/tests.yml` to include Laravel 13 and PHPUnit 12, and updated the matrix to handle compatibility between PHP, Laravel, and PHPUnit versions.
* Updated the workflow to require the appropriate version of PHPUnit during dependency installation, ensuring the correct version is tested for each matrix combination.
* Enabled manual triggering of the test workflow by adding `workflow_dispatch` to the list of triggers.